### PR TITLE
Support managed users during initialization imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Bundled PostGIS versions for the `*-postgis` tags:
 | `POSTGRES_DEFAULT_TEXT_SEARCH_CONFIG`   | `pg_catalog.english` |                    |
 | `POSTGRES_EFFECTIVE_CACHE_SIZE`         | `1GB`                |                    |
 | `POSTGRES_DB_EXTENSIONS`                |                      | Separated by comma |
+| `POSTGRES_INITDB_PASSWORD`              |                      | Password for the optional role created before initialization imports |
+| `POSTGRES_INITDB_USER`                  |                      | Optional role created before initialization imports |
 | `POSTGRES_LC_MESSAGES`                  | `en_US.utf8`         |                    |
 | `POSTGRES_LC_MONETARY`                  | `en_US.utf8`         |                    |
 | `POSTGRES_LC_NUMERIC`                   | `en_US.utf8`         |                    |
@@ -86,6 +88,10 @@ Bundled PostGIS versions for the `*-postgis` tags:
 | `POSTGRES_USER`                         | `postgres`           |                    |
 | `POSTGRES_WAL_BUFFERS`                  | `16MB`               |                    |
 | `POSTGRES_WORK_MEM`                     | `5MB`                |                    |
+
+Files mounted at `/wodby/import` are processed after the image's built-in initialization scripts. Set
+`POSTGRES_INITDB_USER` and `POSTGRES_INITDB_PASSWORD` together when imported SQL contains objects owned by a role that
+must exist before the import starts. These variables do not replace the `POSTGRES_USER` cluster administrator.
 
 ## Orchestration Actions
 

--- a/initdb.d/00-create-import-user.sh
+++ b/initdb.d/00-create-import-user.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -z "${POSTGRES_INITDB_USER:-}" && -z "${POSTGRES_INITDB_PASSWORD:-}" ]]; then
+    exit 0
+fi
+
+if [[ -z "${POSTGRES_INITDB_USER:-}" || -z "${POSTGRES_INITDB_PASSWORD:-}" ]]; then
+    echo "POSTGRES_INITDB_USER and POSTGRES_INITDB_PASSWORD must be specified together" >&2
+    exit 1
+fi
+
+# Avoid exposing the managed password in DEBUG output while passing it to psql.
+restore_xtrace=0
+if [[ -o xtrace ]]; then
+    restore_xtrace=1
+    set +x
+fi
+
+psql \
+    --username "${POSTGRES_USER}" \
+    --dbname "${POSTGRES_DB}" \
+    --set ON_ERROR_STOP=1 \
+    --set managed_user="${POSTGRES_INITDB_USER}" \
+    --set managed_password="${POSTGRES_INITDB_PASSWORD}" <<-'EOSQL'
+	SELECT format(
+	    'CREATE ROLE %I LOGIN PASSWORD %L',
+	    :'managed_user',
+	    :'managed_password'
+	)
+	WHERE NOT EXISTS (
+	    SELECT 1
+	    FROM pg_catalog.pg_roles
+	    WHERE rolname = :'managed_user'
+	)
+	\gexec
+EOSQL
+
+if [[ "${restore_xtrace}" == "1" ]]; then
+    set -x
+fi

--- a/initdb.d/zz-import.sh
+++ b/initdb.d/zz-import.sh
@@ -1,0 +1,12 @@
+# This file is intentionally not executable. The upstream PostgreSQL entrypoint
+# sources it so docker_process_init_files remains available here.
+
+if [[ -d /wodby/import ]]; then
+    shopt -s nullglob
+    wodby_import_files=(/wodby/import/*)
+    if (( ${#wodby_import_files[@]} > 0 )); then
+        docker_process_init_files "${wodby_import_files[@]}"
+    fi
+    unset wodby_import_files
+    shopt -u nullglob
+fi

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -9,6 +9,24 @@ fi
 export POSTGRES_PASSWORD='password'
 export POSTGRES_USER='superuser'
 export POSTGRES_DB='postgres'
+export POSTGRES_INITDB_USER='managed_user'
+export POSTGRES_INITDB_PASSWORD='managed-password'
+
+import_dir="$(mktemp -d)"
+cid=''
+cleanup() {
+	if [[ -n "${cid}" ]]; then
+		docker rm -vf "${cid}" >/dev/null
+	fi
+	rm -r "${import_dir}"
+}
+trap cleanup EXIT
+
+cat > "${import_dir}/import.sql" <<'SQL'
+CREATE TABLE managed_import_test (value text NOT NULL);
+ALTER TABLE managed_import_test OWNER TO managed_user;
+INSERT INTO managed_import_test VALUES ('imported');
+SQL
 
 required_extensions=(pg_trgm)
 if [[ "${TEST_POSTGIS}" == "1" ]]; then
@@ -30,12 +48,14 @@ cid="$(
 		-e POSTGRES_PASSWORD \
 		-e POSTGRES_USER \
 		-e POSTGRES_DB \
+		-e POSTGRES_INITDB_USER \
+		-e POSTGRES_INITDB_PASSWORD \
 		-e POSTGRES_DB_EXTENSIONS="${db_extensions}" \
 		-e DEBUG \
+		-v "${import_dir}:/wodby/import:ro" \
 		--name "${NAME}" \
 		"${IMAGE}"
 )"
-trap "docker rm -vf ${cid} > /dev/null" EXIT
 
 postgres() {
 	docker run --rm -i \
@@ -48,6 +68,11 @@ postgres() {
 }
 
 postgres make check-ready max_try=12 wait_seconds=5
+
+echo -n "Checking initialization import user... "
+[ "$(postgres make query-silent user="${POSTGRES_INITDB_USER}" password="${POSTGRES_INITDB_PASSWORD}" query='SELECT value FROM managed_import_test')" = 'imported' ]
+[ "$(postgres make query-silent query="SELECT tableowner FROM pg_catalog.pg_tables WHERE tablename = 'managed_import_test'")" = "${POSTGRES_INITDB_USER}" ]
+echo "OK"
 
 echo -n "Checking extensions... "
 installed_extensions="$(postgres make query-silent query='SELECT extname FROM pg_extension ORDER BY 1')"


### PR DESCRIPTION
PostgreSQL initialization imports can contain objects owned by an application role that is not part of a database-only dump. A fresh cluster previously had only its administrator role, so those imports failed when PostgreSQL tried to restore object ownership.

This change can create an optional managed login role before initialization imports, then processes files mounted at `/wodby/import` without replacing the image’s built-in initialization directory. The administrator account remains unchanged.

Validation:
- `bash -n initdb.d/00-create-import-user.sh initdb.d/zz-import.sh tests/run.sh`
- `make build`
- `make test`
- `git diff --check`