### PR TITLE
Make initialization import fixture readable

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -13,6 +13,7 @@ export POSTGRES_INITDB_USER='managed_user'
 export POSTGRES_INITDB_PASSWORD='managed-password'
 
 import_dir="$(mktemp -d)"
+chmod 755 "${import_dir}"
 cid=''
 cleanup() {
 	if [[ -n "${cid}" ]]; then


### PR DESCRIPTION
The initialization-import integration test used a host directory that only its owner could traverse. Linux containers run PostgreSQL initialization as a different user, so the mounted SQL fixture was invisible even though Docker Desktop accepted the same setup.

This change makes the temporary fixture directory traversable while keeping the mounted data read-only.

Validation:
- reproduced by the PostgreSQL 18 amd64 `master` job
- `bash -n tests/run.sh`
- `git diff --check`