### PR TITLE
Add streaming database backups

### DIFF
--- a/bin/actions.mk
+++ b/bin/actions.mk
@@ -29,6 +29,11 @@ backup:
 	$(call check_defined, filepath)
 	backup $(user) $(password) $(host) $(db) $(filepath) "$(ignore)" $(nice) $(ionice)
 
+backup-stream:
+	$(call check_defined, stream_path, status_path)
+	backup_stream $(user) $(password) $(host) $(db) $(stream_path) $(status_path) "$(ignore)" $(nice) $(ionice)
+.PHONY: backup-stream
+
 query:
 	$(call check_defined, query)
 	PGPASSWORD=$(password) psql -U$(user) -h$(host) -d$(db) -c "$(query)"

--- a/bin/backup_stream
+++ b/bin/backup_stream
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -eEo pipefail
+
+if [[ -n "${DEBUG}" ]]; then
+    set -x
+fi
+
+user=$1
+password=$2
+host=$3
+db=$4
+stream_path=$5
+status_path=$6
+exclude_tables=$7
+nice=$8
+ionice=$9
+
+write_status() {
+    exit_code=$?
+    status_tmp="${status_path}.tmp.$$"
+    printf '%s\n' "${exit_code}" > "${status_tmp}"
+    mv "${status_tmp}" "${status_path}"
+}
+trap write_status EXIT
+
+# Open the FIFO before any database work so the uploader receives EOF even if
+# preparing the dump fails before the first byte is produced.
+exec 3> "${stream_path}"
+
+ignore=()
+
+IFS=';' read -ra ADDR <<< "${exclude_tables}"
+for table in "${ADDR[@]}"; do
+    ignore+=("--exclude-table-data=${table}")
+done
+
+PGPASSWORD="${password}" \
+    nice -n "${nice}" ionice -c2 -n "${ionice}" \
+    pg_dump "${ignore[@]}" -U"${user}" -h"${host}" "${db}" | gzip >&3

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -177,6 +177,50 @@ echo -n "Checking ignored tables from backup/import... "
 [ "$(postgres make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]
 echo "OK"
 
+echo -n "Running streaming backup and restore... "
+stream_dir="$(mktemp -d)"
+chmod 777 "${stream_dir}"
+docker run --rm \
+    -e POSTGRES_USER -e POSTGRES_PASSWORD -e POSTGRES_DB \
+    -v "${stream_dir}:/stream" \
+    --link "${NAME}":postgres \
+    "${IMAGE}" bash -ceu '
+        mkfifo /stream/data
+        touch /stream/status
+        chmod 666 /stream/data /stream/status
+        cat /stream/data > /stream/export.sql.gz &
+        reader=$!
+        make -f /usr/local/bin/actions.mk backup-stream \
+            host=postgres \
+            ignore="test1;test2" \
+            stream_path=/stream/data \
+            status_path=/stream/status
+        wait "${reader}"
+        test "$(cat /stream/status)" = 0
+
+        rm /stream/data /stream/status
+        mkfifo /stream/data
+        touch /stream/status
+        chmod 666 /stream/data /stream/status
+        cat /stream/data >/dev/null &
+        reader=$!
+        if make -f /usr/local/bin/actions.mk backup-stream \
+            host=postgres \
+            db=missing_stream_backup_database \
+            stream_path=/stream/data \
+            status_path=/stream/status; then
+            exit 1
+        fi
+        wait "${reader}"
+        test "$(cat /stream/status)" != 0
+    '
+postgres make import source="${stream_dir}/export.sql.gz"
+[ "$(postgres make query-silent query='SELECT COUNT(*) FROM test')" = 1 ]
+[ "$(postgres make query-silent query='SELECT COUNT(*) FROM test1')" = 0 ]
+[ "$(postgres make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]
+rm -rf "${stream_dir}"
+echo "OK"
+
 echo -n "Running import from URL source (.zip)... "
 postgres make import source="https://s3.amazonaws.com/wodby-sample-files/postgres-import-test/export.zip"
 echo "OK"


### PR DESCRIPTION
PostgreSQL backups currently write the entire compressed dump into the database volume before it can be uploaded. This change adds a separate streaming action that writes the dump to a FIFO, while leaving the established staged action unchanged for existing consumers.

## What changed

- add a `backup_stream` producer script
- add the `backup-stream` Make target without changing `backup`
- publish producer completion through an atomic status file
- open the FIFO before database preparation so early failures still deliver EOF to the uploader
- add successful restore and failed-producer coverage to the image test suite

## Validation

- `bash -n bin/backup_stream tests/run.sh`
- `git diff --check`

The Docker-backed database matrix was not run locally; the new cases execute as part of the image build workflow.

## Release

After merge and successful image builds, create annotated release tag `1.45.0`.
