### PR TITLE
Fix streaming backup restore test path

### DIFF
--- a/tests/run.sh
+++ b/tests/run.sh
@@ -214,7 +214,12 @@ docker run --rm \
         wait "${reader}"
         test "$(cat /stream/status)" != 0
     '
-postgres make import source="${stream_dir}/export.sql.gz"
+docker run --rm -i \
+    -e POSTGRES_USER -e POSTGRES_PASSWORD -e POSTGRES_DB -e DEBUG \
+    -v "${stream_dir}:/stream" \
+    --link "${NAME}":postgres \
+    "${IMAGE}" \
+    make import source=/stream/export.sql.gz host=postgres
 [ "$(postgres make query-silent query='SELECT COUNT(*) FROM test')" = 1 ]
 [ "$(postgres make query-silent query='SELECT COUNT(*) FROM test1')" = 0 ]
 [ "$(postgres make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]


### PR DESCRIPTION
The streaming backup test wrote its archive into a host temporary directory, then passed that host path to a separate container where the directory was mounted elsewhere. The import step therefore could not find the archive and failed the image build. This change mounts the archive directory explicitly at `/stream` in the import helper and uses that container-visible path.

## Validation

- `make POSTGRES_VER=16.15 ARCH=arm64`
- `make test POSTGRES_VER=16.15 ARCH=arm64`
- `bash -n tests/run.sh`
- `git diff --check`
